### PR TITLE
Reverted the UI env variable removal in setup function

### DIFF
--- a/functions/setup.js
+++ b/functions/setup.js
@@ -47,6 +47,7 @@ exports.handler = async function (context, event, callback) {
   const sourceMapUri = `${pluginBaseUrl}/bundle.js.map`;
   const replacementMap = {
     '<FLEX_APP_SERVERLESS_FUNCTONS_DOMAIN>': 'https://' + context.DOMAIN_NAME,
+    '<FLEX_APP_CALLBACK_RETRY_ATTEMPTS>': context.CALLBACK_RETRY_ATTEMPTS,
   };
   const serviceSid = event.serviceSid;
   const serverlessClient = new TwilioServerlessApiClient({


### PR DESCRIPTION
## Description

JIRA: [FLEXY-4563](https://issues.corp.twilio.com/browse/FLEXY-4563)

Reverted the UI env variable removal in setup function which was mistakenly removed while making changes in setup function for Upgrade plugin functionality

## Test Plan

- Install the plugin
- The plugin bundle should have the value hardcoded in it for CALLBACK_RETRY_ATTEMPTS which was passed during installation

## Checklist

- [ ] Individual public Repo in Twilio Github.com
- [ ] Test the plugin against Flex UI 2.x for compatibility
- [ ] Create plugin specific CI/CD files
- [ ] Unit test for UI code and serverless code (80% coverage)
- [ ] setup.js should be mandatorily part of the serverless functions
- [ ] Telemetry - Make use of the manager.reportPluginInteraction() to send the event data to Kibana
- [ ] For logging, console.log/warn/error should be effectively used with enough contextual information (these will by default show up in debugger once enabled)
- [ ] Exception handling with degraded UX or information to UI along with serverless retry mechanism (for wherever applicable)
  - 5xx should be handled with retry mechanism (max of 3 attempts)
  - 4xx should be reported back to user saying "Please try after some time...."
- [ ] Details.md file to have content that needs to show up on PluginsLibrary frontend
- [ ] License file to be added in the repo
- [ ] Readme.md updated
- [ ] Plugin template should have a screeshot folder, which contains one image (1.gif) of 1280 x 720 resolution (16:9 aspect ratio).
- [ ] Snyk integration for security vulenrabilities (fix them if there are any)
- [ ] CodeCov integration for testing coverage
- [ ] E2E test suite for the entire plugin
- [ ] For E2E or any automated test, container components and user interactable child components must have ID attribute set.
